### PR TITLE
Bugfix: Some named arguments cause image.decode argument error

### DIFF
--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -38,13 +38,6 @@
   let font = named-args.at("font",default:"Arial")
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
-  if (factor != none){
-    let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
 
-    let new-width = int(svg-width) * factor * 1pt
-    named-args.insert("width", new-width) 
-    let junk = named-args.remove("factor")
-  }
   svg-output
 }
-

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -3,9 +3,9 @@
 #let pintora-src = read("./pintora.js")
 #let pintora-bytecode = compile-js(pintora-src)
 
-#let getWidth(svg-output, factor) = {
+#let getNewWidth(svg-output, factor, width) = {
   if (factor == none) {
-    return auto
+    return width
   }
 
   let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
@@ -20,13 +20,19 @@
   let style = named-args.at("style",default:"larkLight")
   let font = named-args.at("font",default:"Arial")
 
+  let width = named-args.at("width",default:auto)
+
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
-  let width = getWidth(svg-output, factor)
+  let width = getNewWidth(svg-output, factor, width)
 
   image.decode(
     svg-output, 
     width: width,
+    format: named-args.at("format", default:auto),
+    height: named-args.at("height", default:auto),
+    alt: named-args.at("alt", default:none),
+    fit: named-args.at("fit", default:"cover")
   )
 }
 
@@ -37,7 +43,6 @@
   let style = named-args.at("style",default:"larkLight")
   let font = named-args.at("font",default:"Arial")
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
-
 
   svg-output
 }

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -8,6 +8,10 @@
     return width
   }
 
+  if (width != auto) {
+    panic("invalid arguments. factor and width cannot both be set.")
+  }
+
   let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
   return int(svg-width) * factor * 1pt
 }

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -9,8 +9,7 @@
   }
 
   let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
-  let width = int(svg-width) * factor * 1pt
-  return width
+  return int(svg-width) * factor * 1pt
 }
 
 #let render(

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -3,6 +3,16 @@
 #let pintora-src = read("./pintora.js")
 #let pintora-bytecode = compile-js(pintora-src)
 
+#let getWidth(svg-output, factor) = {
+  if (factor == none) {
+    return auto
+  }
+
+  let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
+  let width = int(svg-width) * factor * 1pt
+  return width
+}
+
 #let render(src, ..args) = {
   let named-args = args.named()
   let factor = named-args.at("factor",default:none)
@@ -10,13 +20,8 @@
   let font = named-args.at("font",default:"Arial")
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
-  if (factor != none){
-    let svg-width = svg-output.find(regex("width=\"(\d+)")).find(regex("\d+"))
+  let width = getWidth(svg-output, factor)
 
-    let new-width = int(svg-width) * factor * 1pt
-    named-args.insert("width", new-width) 
-    let junk = named-args.remove("factor")
-  }
   image.decode(svg-output, ..args.pos(), ..named-args)
 }
 

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -15,14 +15,19 @@
 
 #let render(src, ..args) = {
   let named-args = args.named()
+
   let factor = named-args.at("factor",default:none)
   let style = named-args.at("style",default:"larkLight")
   let font = named-args.at("font",default:"Arial")
+
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
   let width = getWidth(svg-output, factor)
 
-  image.decode(svg-output, ..args.pos(), ..named-args)
+  image.decode(
+    svg-output, 
+    width: width,
+  )
 }
 
 #let render-svg(src, ..args) = {

--- a/package/pintorita.typ
+++ b/package/pintorita.typ
@@ -13,35 +13,33 @@
   return width
 }
 
-#let render(src, ..args) = {
+#let render(
+  src,
+  factor: none,
+  style: "larkLight",
+  font: "Arial",
+  width: auto,
+  ..args,
+) = {
   let named-args = args.named()
-
-  let factor = named-args.at("factor",default:none)
-  let style = named-args.at("style",default:"larkLight")
-  let font = named-args.at("font",default:"Arial")
-
-  let width = named-args.at("width",default:auto)
 
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
-  let width = getNewWidth(svg-output, factor, width)
+  let newWidth = getNewWidth(svg-output, factor, width)
 
   image.decode(
-    svg-output, 
-    width: width,
-    format: named-args.at("format", default:auto),
-    height: named-args.at("height", default:auto),
-    alt: named-args.at("alt", default:none),
-    fit: named-args.at("fit", default:"cover")
+    svg-output,
+    width: newWidth,
+    ..args,
   )
 }
 
-#let render-svg(src, ..args) = {
+#let render-svg(
+  src,
+  style: "larkLight",
+  font: "Arial",
+) = {
   // style: ["default", "larkLight", "larkDark", "dark"]
-  let named-args = args.named()
-  let factor = named-args.at("factor",default:none)
-  let style = named-args.at("style",default:"larkLight")
-  let font = named-args.at("font",default:"Arial")
   let svg-output = call-js-function(pintora-bytecode, "PintoraRender", src, style, font)
 
   svg-output


### PR DESCRIPTION
This PR is an idea on how to fix #4, were `args` that are not supported by [image.decode](https://typst.app/docs/reference/visualize/image/#definitions-decode) are parsed down.

Manually listing the arguments should help separating the arguments used by `pintorita` and `image.decode`.

I have left the `image.decode` arguments as `..args`.
If you pass an extra argument that is not supported by `image.decode` the compiler will still scream at you.

I also made `render` fail if both width and factor are set. It could be confusing, if the width is just ignored and you don't know why.
